### PR TITLE
Hindex error fix

### DIFF
--- a/src/CDmetaPOP_mainloop.py
+++ b/src/CDmetaPOP_mainloop.py
@@ -226,7 +226,7 @@ def main_loop(spcNO,fileans,irun,datadir,sizeans,constMortans,mcruns,looptime,nt
 		validate(not (inheritans_classfiles == 'random' or inheritans_classfiles == 'Hindex' or inheritans_classfiles == 'mother'),'Inherit answer for multiple class files is not correct: enter either random or Hindex.')
 				
 		# If inherit answer uses Hindex, mutation can't be on
-		if isinstance(muterate_pass, list) > 1:
+		if isinstance(muterate_pass, list):
 			validate(sum(np.asarray(muterate_pass,dtype=float)) != 0.0 and (inheritans_classfiles == 'Hindex' or inheritans_classfiles == 'mother'),'Mutation is not operating with Hindex inheritance options in this version.')
 		else:
 			validate(sum(np.asarray([muterate_pass],dtype=float)) != 0.0 and (inheritans_classfiles == 'Hindex' or inheritans_classfiles == 'mother'),'Mutation is not operating with Hindex inheritance options in this version.')


### PR DESCRIPTION
Fixes error: 'Mutation is not operating with Hindex inheritance options in this version.' when Hindex inheritance options aren't being used.