### PR TITLE
Add an environment file with a numpy version that works

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Requirements and Pre-requisite Software
 
 `conda deactivate`
 
+Or, use the environment file provided with CDMetaPOP:
+
+`conda env create -f environment.yml`
+
+`conda activate cdmetapop`
+
 ---------------------------
 CDMetaPOP v3.0 Installation
 --------------------------- 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: cdmetapop
+channels:
+    - conda-forge
+    - bioconda
+dependencies:
+    - python
+    - numpy=2.3.5
+    - scipy
+    - pandas


### PR DESCRIPTION
CDMetaPOP works with numpy <= 2.3.5. This pull request adds a conda environment file so that users can easily install the correct versions of required packages. It also adds instructions for using the environment file to the README.